### PR TITLE
add the retry flag to tests

### DIFF
--- a/src/__tests__/reporter/startSuiteTestReporting.spec.ts
+++ b/src/__tests__/reporter/startSuiteTestReporting.spec.ts
@@ -72,6 +72,7 @@ describe('start reporting suite/test', () => {
       name: testParams.title,
       type: TEST_ITEM_TYPES.STEP,
       codeRef: 'test/example.js/rootDescribe/parentDescribe/testTitle',
+      retry: false,
     };
 
     test('client.startTestItem should be called with corresponding params', () => {

--- a/src/models/reporting.ts
+++ b/src/models/reporting.ts
@@ -33,6 +33,7 @@ export interface StartTestObjType {
   startTime?: Date | number;
   codeRef?: string;
   testCaseId?: string;
+  retry?: boolean;
 }
 
 export interface FinishTestItemObjType {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -243,7 +243,7 @@ class RPReporter implements Reporter {
         startTime: this.client.helpers.now(),
         type: TEST_ITEM_TYPES.STEP,
         codeRef,
-        retry: test.results.length > 1
+        retry: test.results.length > 1,
       };
       const stepObj = this.client.startTestItem(startTestItem, this.launchId, parentId);
       this.addRequestToPromisesQueue(stepObj.promise, 'Failed to start test.');

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -243,7 +243,7 @@ class RPReporter implements Reporter {
         startTime: this.client.helpers.now(),
         type: TEST_ITEM_TYPES.STEP,
         codeRef,
-        retry: test.results.length > 1,
+        retry: (typeof test.results === "undefined") ? false : test.results.length > 1,
       };
       const stepObj = this.client.startTestItem(startTestItem, this.launchId, parentId);
       this.addRequestToPromisesQueue(stepObj.promise, 'Failed to start test.');

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -243,6 +243,7 @@ class RPReporter implements Reporter {
         startTime: this.client.helpers.now(),
         type: TEST_ITEM_TYPES.STEP,
         codeRef,
+        retry: test.results.length > 1
       };
       const stepObj = this.client.startTestItem(startTestItem, this.launchId, parentId);
       this.addRequestToPromisesQueue(stepObj.promise, 'Failed to start test.');


### PR DESCRIPTION
Thanks for starting the playwright agent!

This is a small PR that sets the `retry` flag when there are more than 1 result for a test, which means that it's a retry