### PR TITLE
support mode in config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2299,6 +2299,14 @@
         "universal-analytics": "^0.4.20"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        },
         "glob": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -3975,9 +3983,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@reportportal/client-javascript": "^5.0.6",
+    "axios": "^0.24.0",
     "strip-ansi": "^6.0.1"
   },
   "files": [

--- a/src/__tests__/reporter/launchesReporting.spec.ts
+++ b/src/__tests__/reporter/launchesReporting.spec.ts
@@ -16,30 +16,62 @@
  */
 
 import { RPReporter } from '../../reporter';
-import { mockConfig } from '../mocks/configMock';
 import { StartLaunchObjType } from '../../models';
-import { RPClientMock } from '../mocks/RPClientMock';
 import { getSystemAttributes } from '../../utils';
+import { LAUNCH_MODES } from '../../constants';
+
+import { mockConfig } from '../mocks/configMock';
+import { RPClientMock } from '../mocks/RPClientMock';
 
 describe('start report launch', () => {
-  const reporter = new RPReporter(mockConfig);
-  reporter.client = new RPClientMock(mockConfig);
-  const startLaunchObj: StartLaunchObjType = {
-    name: mockConfig.launch,
-    startTime: reporter.client.helpers.now(),
-    attributes: getSystemAttributes(),
-    description: mockConfig.description,
-  };
+  describe('DEFAULT mode', () => {
+    const reporter = new RPReporter(mockConfig);
+    reporter.client = new RPClientMock(mockConfig);
+    const startLaunchObj: StartLaunchObjType = {
+      name: mockConfig.launch,
+      startTime: reporter.client.helpers.now(),
+      attributes: getSystemAttributes(),
+      description: mockConfig.description,
+      mode: LAUNCH_MODES.DEFAULT,
+    };
 
-  reporter.onBegin();
+    beforeAll(() => reporter.onBegin());
 
-  test('client.startLaunch should be called with corresponding params', () => {
-    expect(reporter.client.startLaunch).toHaveBeenCalledTimes(1);
-    expect(reporter.client.startLaunch).toHaveBeenCalledWith(startLaunchObj);
+    test('client.startLaunch should be called with corresponding params', () => {
+      expect(reporter.client.startLaunch).toHaveBeenCalledTimes(1);
+      expect(reporter.client.startLaunch).toHaveBeenCalledWith(startLaunchObj);
+    });
+
+    test('reporter.launchId should be set', () => {
+      expect(reporter.launchId).toEqual('tempLaunchId');
+    });
   });
 
-  test('reporter.launchId should be set', () => {
-    expect(reporter.launchId).toEqual('tempLaunchId');
+  describe('DEBUG mode', () => {
+    const customConfig = {
+      ...mockConfig,
+      mode: LAUNCH_MODES.DEBUG,
+    };
+    const reporter = new RPReporter(customConfig);
+    reporter.client = new RPClientMock(customConfig);
+    const startLaunchObj: StartLaunchObjType = {
+      name: customConfig.launch,
+      startTime: reporter.client.helpers.now(),
+      attributes: getSystemAttributes(),
+      description: customConfig.description,
+      mode: customConfig.mode,
+    };
+
+    beforeAll(() => reporter.onBegin());
+
+    test('should allow to pass mode to startLaunch', () => {
+      expect(reporter.client.startLaunch).toHaveBeenCalledTimes(1);
+      expect(reporter.client.startLaunch).toHaveBeenCalledWith(startLaunchObj);
+    });
+
+    test('reporter.launchId should be set', () => {
+      expect(reporter.launchId).toEqual('tempLaunchId');
+    });
   });
 });
 
@@ -48,8 +80,9 @@ describe('finish report launch', () => {
   reporter.client = new RPClientMock(mockConfig);
   reporter.launchId = 'tempLaunchId';
 
+  beforeAll(() => reporter.onEnd());
+
   test('launch should be finished', () => {
-    reporter.onEnd();
     expect(reporter.client.finishLaunch).toHaveBeenCalledTimes(1);
     expect(reporter.client.finishLaunch).toHaveBeenCalledWith('tempLaunchId', {
       endTime: reporter.client.helpers.now(),

--- a/src/models/configs.ts
+++ b/src/models/configs.ts
@@ -18,6 +18,14 @@
 import { Attribute } from './common';
 import { LAUNCH_MODES } from '../constants';
 
+export interface AgentOptions {
+  rejectUnauthorized?: boolean;
+}
+
+export interface RestClientConfig {
+  agent?: AgentOptions;
+}
+
 export interface ReportPortalConfig {
   token: string;
   project: string;
@@ -33,4 +41,5 @@ export interface ReportPortalConfig {
   isLaunchMergeRequired?: boolean;
   skippedIssue?: boolean;
   includeTestSteps?: boolean;
+  restClientConfig?: RestClientConfig;
 }

--- a/src/models/configs.ts
+++ b/src/models/configs.ts
@@ -15,14 +15,13 @@
  *
  */
 
+import { AxiosRequestConfig } from 'axios';
+import { AgentOptions } from 'https';
+
 import { Attribute } from './common';
 import { LAUNCH_MODES } from '../constants';
 
-export interface AgentOptions {
-  rejectUnauthorized?: boolean;
-}
-
-export interface RestClientConfig {
+export interface RestClientConfig extends AxiosRequestConfig {
   agent?: AgentOptions;
 }
 

--- a/src/models/reporting.ts
+++ b/src/models/reporting.ts
@@ -16,7 +16,7 @@
  */
 
 import { Attribute } from './common';
-import { TEST_ITEM_TYPES, LOG_LEVELS } from '../constants';
+import { TEST_ITEM_TYPES, LOG_LEVELS, LAUNCH_MODES } from '../constants';
 
 export interface StartLaunchObjType {
   startTime?: Date | number;
@@ -25,6 +25,7 @@ export interface StartLaunchObjType {
   name?: string;
   rerun?: boolean;
   rerunOf?: string;
+  mode?: LAUNCH_MODES;
 }
 
 export interface StartTestObjType {

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -32,7 +32,7 @@ import {
   StartLaunchObjType,
   StartTestObjType,
 } from './models';
-import { LOG_LEVELS, STATUSES, TEST_ITEM_TYPES } from './constants';
+import { LAUNCH_MODES, LOG_LEVELS, STATUSES, TEST_ITEM_TYPES } from './constants';
 import {
   convertToRpStatus,
   getAgentInfo,
@@ -256,7 +256,7 @@ export class RPReporter implements Reporter {
   }
 
   onBegin(): void {
-    const { launch, description, attributes, skippedIssue, rerun, rerunOf } = this.config;
+    const { launch, description, attributes, skippedIssue, rerun, rerunOf, mode } = this.config;
     const systemAttributes: Attribute[] = getSystemAttributes(skippedIssue);
 
     const startLaunchObj: StartLaunchObjType = {
@@ -267,6 +267,7 @@ export class RPReporter implements Reporter {
         attributes && attributes.length ? attributes.concat(systemAttributes) : systemAttributes,
       rerun,
       rerunOf,
+      mode: mode || LAUNCH_MODES.DEFAULT,
     };
     const { tempId, promise } = this.client.startLaunch(startLaunchObj);
     this.addRequestToPromisesQueue(promise, 'Failed to launch run.');


### PR DESCRIPTION
Hello, 
I have found that config 'mode' parameter has no any effect on launch.  
During my investigations I have discovered that this parameter isn't a part of **StartLaunchObjType** and so it wasn't pass to reporter,startLaunch. 
My changes fix this as well as add possibility to provide config **restClientConfig** parameter that can be passed to client-javascript (https://github.com/reportportal/client-javascript#settings) .