### PR TITLE
EPMRPP-79077 || Failed to start suite

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -499,7 +499,7 @@ export class RPReporter implements Reporter {
     const testFilePath = getTestFilePath(test, test.title);
 
     Array.from(this.suites)
-      .filter(([key]) => key.includes(testFilePath))
+      .filter(([key]) => key.includes(fullParentName) || key === testFilePath)
       .map(([key, { testsLength }]) => {
         this.suites.set(key, {
           ...this.suites.get(key),


### PR DESCRIPTION
Also user points that he has the same error when he tried to run default
test witch generated by playwright itself. The main problem was when
onTestEnd hook runs, we must to decrease testsLength property only in rootTestsObject,
and in object, witch contains information only about test witch currently ends.
Previously it decrease the testsLength in all testsObjects.
https://github.com/reportportal/agent-js-playwright/issues/57