### PR TITLE
Fix Cannot redefine property: id error

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -417,9 +417,11 @@ export class RPReporter implements Reporter {
       startTime: this.client.helpers.now(),
     };
 
-    Object.defineProperty(step, 'id', {
-      value: randomUUID(),
-    });
+    if (!step.hasOwnProperty('id')) {
+      Object.defineProperty(step, 'id', {
+        value: randomUUID(),
+      });
+    }
 
     const stepName = getCodeRef(step, step.title);
     const fullStepName = `${test.id}/${stepName}-${step.id}`;


### PR DESCRIPTION
In my use case, some of the step objects are already containing an id and this line throws an error.